### PR TITLE
Removed link in 2020.2.12 meeting minutes to 2019.1.29

### DIFF
--- a/docs/meeting-minutes/2020.2.12-pilot-project-minutes.md
+++ b/docs/meeting-minutes/2020.2.12-pilot-project-minutes.md
@@ -12,7 +12,7 @@ sidebar_label: 2020.2.12
 ### Introductions
 
 ### Review and Approve 2020.1.29 Meeting Minutes
-* [2020.1.29 Meeting Minutes](2020.1.29-pilot-project-minutes.md)
+* 2020.1.29 Meeting Minutes
 
 ### Pilot Participant On-Boarding
 


### PR DESCRIPTION
Removed link in 2020.2.12 meeting minutes to 2019.1.29 which was causing an error in the build process. 